### PR TITLE
The timer_poll_func() is freezed  in main process after fork calling.

### DIFF
--- a/qat_asym_common.c
+++ b/qat_asym_common.c
@@ -178,6 +178,7 @@ int qat_mod_exp(BIGNUM *res, const BIGNUM *base, const BIGNUM *exp,
         }
     }
 
+    instance_handle = get_next_inst();
     if (qat_use_signals()) {
         qat_atomic_inc(num_requests_in_flight);
         pthread_kill_ret = pthread_kill(timer_poll_func_thread, SIGUSR1);

--- a/qat_ciphers.c
+++ b/qat_ciphers.c
@@ -1212,6 +1212,7 @@ int qat_chained_ciphers_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
         return -1;
     }
 
+    get_next_inst();
     if (qat_use_signals()) {
         qat_atomic_inc(num_requests_in_flight);
         pthread_kill_ret = pthread_kill(timer_poll_func_thread, SIGUSR1);

--- a/qat_dh.c
+++ b/qat_dh.c
@@ -310,6 +310,7 @@ int qat_dh_generate_key(DH *dh)
         goto err;
     }
 
+    instance_handle = get_next_inst();
     if (qat_use_signals()) {
         qat_atomic_inc(num_requests_in_flight);
         pthread_kill_ret = pthread_kill(timer_poll_func_thread, SIGUSR1);
@@ -557,6 +558,7 @@ int qat_dh_compute_key(unsigned char *key, const BIGNUM *in_pub_key, DH *dh)
         goto err;
     }
 
+    instance_handle = get_next_inst();
     if (qat_use_signals()) {
         qat_atomic_inc(num_requests_in_flight);
         pthread_kill_ret = pthread_kill(timer_poll_func_thread, SIGUSR1);

--- a/qat_dsa.c
+++ b/qat_dsa.c
@@ -392,6 +392,7 @@ DSA_SIG *qat_dsa_do_sign(const unsigned char *dgst, int dlen,
         goto err;
     }
 
+    instance_handle = get_next_inst();
     if (qat_use_signals()) {
         qat_atomic_inc(num_requests_in_flight);
         pthread_kill_ret = pthread_kill(timer_poll_func_thread, SIGUSR1);
@@ -704,6 +705,7 @@ int qat_dsa_do_verify(const unsigned char *dgst, int dgst_len,
         goto err;
     }
 
+    instance_handle = get_next_inst();
     if (qat_use_signals()) {
         qat_atomic_inc(num_requests_in_flight);
         pthread_kill_ret = pthread_kill(timer_poll_func_thread, SIGUSR1);

--- a/qat_ec.c
+++ b/qat_ec.c
@@ -427,6 +427,7 @@ int qat_ecdh_compute_key(unsigned char **outX, size_t *outlenX,
         opData->a.pData[0] = 0;
     }
 
+    instance_handle = get_next_inst();
     if (qat_use_signals()) {
         qat_atomic_inc(num_requests_in_flight);
         pthread_kill_ret = pthread_kill(timer_poll_func_thread, SIGUSR1);
@@ -1082,6 +1083,7 @@ ECDSA_SIG *qat_ecdsa_do_sign(const unsigned char *dgst, int dgst_len,
     pResultS->dataLenInBytes = (Cpa32U) buflen;
 
     /* perform ECDSA sign */
+    instance_handle = get_next_inst();
     if (qat_use_signals()) {
         qat_atomic_inc(num_requests_in_flight);
         pthread_kill_ret = pthread_kill(timer_poll_func_thread, SIGUSR1);
@@ -1441,6 +1443,7 @@ int qat_ecdsa_do_verify(const unsigned char *dgst, int dgst_len,
     }
 
     /* perform ECDSA verify */
+    instance_handle = get_next_inst();
     if (qat_use_signals()) {
         qat_atomic_inc(num_requests_in_flight);
         pthread_kill_ret = pthread_kill(timer_poll_func_thread, SIGUSR1);

--- a/qat_prf.c
+++ b/qat_prf.c
@@ -587,6 +587,7 @@ int qat_prf_tls_derive(EVP_PKEY_CTX *ctx, unsigned char *key,
 
     DUMP_PRF_OP_DATA(prf_op_data);
 
+    instance_handle = get_next_inst();
     if (qat_use_signals()) {
         qat_atomic_inc(num_requests_in_flight);
         pthread_kill_ret = pthread_kill(timer_poll_func_thread, SIGUSR1);

--- a/qat_rsa.c
+++ b/qat_rsa.c
@@ -420,6 +420,7 @@ qat_rsa_decrypt(CpaCyRsaDecryptOpData * dec_op_data, int rsa_len,
 
     DEBUG("- Started\n");
 
+    instance_handle = get_next_inst();
     if (qat_use_signals()) {
         qat_atomic_inc(num_requests_in_flight);
         pthread_kill_ret = pthread_kill(timer_poll_func_thread, SIGUSR1);
@@ -679,6 +680,7 @@ qat_rsa_encrypt(CpaCyRsaEncryptOpData * enc_op_data,
 
     DEBUG("- Started\n");
 
+    instance_handle = get_next_inst();
     if (qat_use_signals()) {
         qat_atomic_inc(num_requests_in_flight);
         pthread_kill_ret = pthread_kill(timer_poll_func_thread, SIGUSR1);


### PR DESCRIPTION
[server.c.txt](https://github.com/01org/QAT_Engine/files/1377745/server.c.txt)

Because,
1) pthread_atfork() function reset timer_poll in main process.
2) qat_use_signals() return false when someone try to use QAT_Engine.
3) QAT_Engine does not call pthread_kill().
4) timer_poll_func() keeps waiting infinitely

To avoid this problem, this patch calling get_next_inst()
before calling qat_use_signals().
See attached sample program to reproduce this bug.
