### PR TITLE
Altered contig_mem driver to compile with newer (4.12.8+) kernels

### DIFF
--- a/qat_contig_mem/qat_contig_mem.c
+++ b/qat_contig_mem/qat_contig_mem.c
@@ -75,6 +75,7 @@
 #include <linux/cdev.h>
 #include <linux/device.h>
 #include <linux/slab.h>
+#include <linux/uaccess.h> 
 
 #include "qat_contig_mem.h"
 


### PR DESCRIPTION
A recent change to the kernel header files made this driver no longer compile as shipped.