### PR TITLE
Update READ.me fix the openssl command for AES-GCM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1613,11 +1613,11 @@ for QAT and Multibuff offload in the configure command.
 cd /path/to/openssl/apps
 
 *AES-128-GCM
-    ./openssl speed -engine qat -elapsed aes-128-gcm
+    ./openssl speed -engine qat -elapsed -evp aes-128-gcm
 *AES-192-GCM
-    ./openssl speed -engine qat -elapsed aes-192-gcm
+    ./openssl speed -engine qat -elapsed -evp aes-192-gcm
 *AES-256-GCM
-    ./openssl speed -engine qat -elapsed aes-256-gcm
+    ./openssl speed -engine qat -elapsed -evp aes-256-gcm
 ```
 
 ## Legal


### PR DESCRIPTION
fix the command for AES-128-GCM/AES-192-GCM/AES-256-GCM to add the -evp
without the -evp, openssl will show unknown algorithm.