### PR TITLE
Makefile: use 'install -D' instead of 'cp -f'.

### DIFF
--- a/.tools/Makefile.am
+++ b/.tools/Makefile.am
@@ -137,7 +137,7 @@ MAKE = make err-files && make
 endif
 
 install-data-am:
-	cp -f .libs/libqatengine.so $(engine_install_dir)/$(with_qat_engine_id).so
+	install -D .libs/libqatengine.so $(engine_install_dir)/$(with_qat_engine_id).so
 
 err-files:
 if QAT_OPENSSL_110


### PR DESCRIPTION
Using 'cp -f' fails if the target directory doesn't exist:

    cp -f .libs/libqat.so /usr/lib64/engines-1.1/qat.so
    cp: cannot create regular file '/usr/lib64/engines-1.1/qat.so': No such file or directory

Using 'install -D' means that the directory path is created in case it doesn't exist.