### PR TITLE
Fix multithread issues in QAT SW.

### DIFF
--- a/qat_sw_init.c
+++ b/qat_sw_init.c
@@ -414,8 +414,6 @@ void mb_thread_local_destructor(void *tlv_ptr)
     } else {
         DEBUG("tlv NULL\n");
     }
-
-    pthread_setspecific(mb_thread_key, NULL);
 }
 
 int multibuff_init(ENGINE *e)
@@ -460,6 +458,8 @@ int multibuff_finish_int(ENGINE *e, int reset_globals)
     }
 
     PRINT_RDTSC_AVERAGES();
+
+    ret = pthread_key_delete(mb_thread_key) == 0;
 
     return ret;
 }

--- a/qat_sw_polling.c
+++ b/qat_sw_polling.c
@@ -357,7 +357,7 @@ void *multibuff_timer_poll_func(void *thread_ptr)
 
     DEBUG("Polling Timeout %ld tlv %p\n", mb_poll_timeout_time.tv_nsec, tlv);
 
-    while (multibuff_keep_polling) {
+    while (tlv->keep_polling && multibuff_keep_polling) {
         while ((sig = sigtimedwait((const sigset_t *)&tlv->set, NULL, &mb_poll_timeout_time)) == -1 &&
                 errno == EINTR &&
                 eintr_count < QAT_SW_NUM_EVENT_RETRIES) {


### PR DESCRIPTION
The thread-specific polling thread doesn't seem to ever exit because the `keep_polling` value wasn't checked. Fix that and a memory leak. Also remove a no-op pthread_setspecific call.