### PR TITLE
minor path change to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Run this command to verify the Intel&reg; QAT OpenSSL\* Engine is loaded
 correctly:
 
 ```text
-cd /path/to/openssl_install/bin
+cd /path/to/openssl_install/apps
 ./openssl engine -t -c -v qatengine
 ```
 


### PR DESCRIPTION
path in below section was changed from /bin to /apps, as that is the sub-folder where "openssl" resides:

cd /path/to/openssl_install/apps