### PR TITLE
Allow compilation against boringssl/master

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -336,12 +336,6 @@ then
       AC_SUBST([LIBQATNAME], "libqatengine")
       CFLAGS_BACK="${CFLAGS}"
       CFLAGS="-I${with_openssl_install_dir}/include/ -I${with_openssl_install_dir}/include/openssl/ ${CFLAGS}"
-      AC_CHECK_TYPE([struct evp_pkey_st], [], [AC_MSG_ERROR([need specified version for BoringSSL commit:15596efa5f])], [
-                     AC_INCLUDES_DEFAULT
-                     #include <openssl/evp.h>])
-      AC_CHECK_MEMBERS([struct evp_pkey_st.references, struct evp_pkey_st.type, struct evp_pkey_st.pkey.ptr, struct evp_pkey_st.pkey.rsa,
-                        struct evp_pkey_st.pkey.dsa, struct evp_pkey_st.pkey.dh, struct evp_pkey_st.pkey.ec, struct evp_pkey_st.ameth],
-                        [], [need specified version for BoringSSL commit:15596efa5f], [#include <openssl/evp.h>])
       CFLAGS="${CFLAGS_BACK}"
     fi
   else

--- a/qat_bssl.c
+++ b/qat_bssl.c
@@ -970,8 +970,8 @@ int bssl_private_key_method_update(EVP_PKEY *pkey)
                 return 1;
             }
 
-            privkey->pkey.rsa->meth->sign_raw = rsa_method->sign_raw;
-            privkey->pkey.rsa->meth->decrypt = rsa_method->decrypt;
+            EVP_PKEY_get0_RSA(pkey)->meth->sign_raw = rsa_method->sign_raw;
+            EVP_PKEY_get0_RSA(pkey)->meth->decrypt = rsa_method->decrypt;
             break;
         case EVP_PKEY_EC:
             if (!(default_algorithm_conf_flags & BSSL_QAT_METHOD_ECDSA)) {
@@ -981,7 +981,7 @@ int bssl_private_key_method_update(EVP_PKEY *pkey)
             if (!ec_method || !ec_method->sign) {
                 return 1;
             }
-            privkey->pkey.ec->ecdsa_meth = ec_method;
+            EVP_PKEY_get0_EC_KEY(pkey)->ecdsa_meth = ec_method;
             break;
         default:
             return 1;


### PR DESCRIPTION
This PR fixes issues relating to compiling versus the master branch of boringssl (currently `ae88f198a49d77993e9c44b017d0e69c810dc668`)