### PR TITLE
typo: `exit_lenstra` -> `exit`

### DIFF
--- a/qat_hw_rsa.c
+++ b/qat_hw_rsa.c
@@ -955,7 +955,7 @@ int qat_rsa_priv_enc(int flen, const unsigned char *from, unsigned char *to,
 
     if ((qat_sw_rsa_priv_req > 0) || qat_get_qat_offload_disabled()) {
         fallback = 1;
-        goto exit_lenstra;
+        goto exit;
     }
 
     START_RDTSC(&qat_hw_rsa_dec_req_prepare);


### PR DESCRIPTION
Fixes: https://github.com/intel/QAT_Engine/issues/251

Looking at `qat_rsa_priv_dec` I think this may be a typo, unless `DISABLE_QAT_HW_LENSTRA_PROTECTION` should be checked? Please advise.