### PR TITLE
Improved documentation for in-tree QAT OpenSSL Engine installation an…

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,9 +288,9 @@ For building QAT Engine against qatlib(intree driver) from source which is
 installed to default location "/usr/local" use `--with-qat_hw_dir=/usr/local`
 or provide the path that is used in the prefix to build qatlib.
 
-If qatlib is installed via RPM then `-with-qat_hw_dir` is not needed as
-qatengine automatically picks qatlib libraries and header from default
-location `/usr/lib64`.
+If qatlib is installed via RPM (both library and development headers) then
+`-with-qat_hw_dir` is not needed as qatengine automatically picks qatlib
+libraries and headers from the default location `/usr/lib64`.
 
 <br>
 </details>
@@ -318,6 +318,11 @@ make install
 In the above example this will create the file `qatengine.so` and copy it to
 the engines dir of the system which can be checked using
 `pkg-config --variable=enginesdir libcrypto`.
+
+If qatlib is installed via RPM (both library and development headers) then
+`-with-qat_hw_dir` is not needed as qatengine automatically picks qatlib
+libraries and headers from the default location `/usr/lib64`.
+
 
 <br>
 </details>


### PR DESCRIPTION
For in-tree installation and usage of the QAT OpenSSL Engine, the documentation omitted a few steps in example 2 (the  parameter '-with-qat_hw_dir`' was not needed) and the need for developer headers.