### PR TITLE
Fix memory leak of session_data on error return path

### DIFF
--- a/qat_hw_sha3.c
+++ b/qat_hw_sha3.c
@@ -325,6 +325,7 @@ static int qat_sha3_session_data_init(EVP_MD_CTX *ctx,
     if (pOpData == NULL) {
         WARN("memory allocation failed for symopData struct.\n");
         QATerr(QAT_F_QAT_SHA3_SESSION_DATA_INIT, ERR_R_MALLOC_FAILURE);
+        free(session_data);
         return 0;
     }
 


### PR DESCRIPTION
There is an error return path that does not free the previously allocated session_data, leading to a memory leak. Free the object before returning on the error return path.