### PR TITLE
Fix missing lower bounds check on index i

### DIFF
--- a/qat_hw_ciphers.c
+++ b/qat_hw_ciphers.c
@@ -1621,7 +1621,7 @@ int qat_chained_ciphers_do_cipher(EVP_CIPHER_CTX *ctx, unsigned char *out,
 
         if (enc) {
             i = plen + dlen;
-            if (i > buflen) {
+            if (i < 0 || i > buflen) {
                 WARN("plen %d or dlen %d out of range, buflen %d\n", plen, dlen, buflen);
                 error = 1;
                 break;


### PR DESCRIPTION
The signed int index i is currently being ranged checked on the upper bounds but not on a negative lower bounds. Add in the missing lower bounds range change to avoid any potentially negative array indexing.

Issue detected using Coverity Scan static analysis