### PR TITLE
Fix build with OPENSSL_NO_ENGINE

### DIFF
--- a/e_qat.c
+++ b/e_qat.c
@@ -340,7 +340,7 @@ __thread unsigned long long num_ecx_sw_derive_reqs = 0;
 __thread unsigned long long num_sm4_cbc_hw_cipher_reqs = 0;
 __thread unsigned long long num_sm4_cbc_sw_cipher_reqs = 0;
 
-#ifndef QAT_BORINGSSL
+#if ! defined(QAT_BORINGSSL) && ! defined(QAT_OPENSSL_PROVIDER)
 const ENGINE_CMD_DEFN qat_cmd_defns[] = {
     {
         QAT_CMD_ENABLE_EXTERNAL_POLLING,
@@ -739,6 +739,7 @@ int qat_engine_finish(ENGINE *e)
  *         ENGINE_init
  ******************************************************************************/
 
+#ifndef QAT_OPENSSL_PROVIDER
 int qat_engine_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
 {
     unsigned int retVal = 1;
@@ -1054,6 +1055,7 @@ int qat_engine_ctrl(ENGINE *e, int cmd, long i, void *p, void (*f) (void))
     }
     return retVal;
 }
+#endif /* QAT_OPENSSL_PROVIDER */
 
 #ifdef ENABLE_QAT_HW_KPT
 EVP_PKEY *qat_engine_load_privkey(ENGINE *e, const char *key_id, UI_METHOD *ui_method, void *callback_data)
@@ -1419,6 +1421,7 @@ int bind_qat(ENGINE *e, const char *id)
     return ret;
 }
 
+#ifndef QAT_OPENSSL_PROVIDER
 #ifndef OPENSSL_NO_DYNAMIC_ENGINE
 IMPLEMENT_DYNAMIC_BIND_FN(bind_qat)
 IMPLEMENT_DYNAMIC_CHECK_FN()
@@ -1501,4 +1504,5 @@ void ENGINE_unload_qat(void)
     }
 }
 #endif /* QAT_BORINGSSL */
+#endif /* QAT_OPENSSL_PROVIDER */
 #endif

--- a/e_qat.h
+++ b/e_qat.h
@@ -46,7 +46,12 @@
 #ifndef E_QAT_H
 # define E_QAT_H
 
-# include <openssl/engine.h>
+# ifdef QAT_OPENSSL_PROVIDER
+#  include <openssl/ec.h>
+#  include <openssl/err.h>
+# else
+#  include <openssl/engine.h>
+# endif
 # include <sys/types.h>
 # include <unistd.h>
 # include <string.h>

--- a/qat_evp.h
+++ b/qat_evp.h
@@ -47,7 +47,11 @@
 # define QAT_EVP_H
 
 
-# include <openssl/engine.h>
+# ifdef QAT_OPENSSL_3
+#  include <openssl/ec.h>
+# else
+#  include <openssl/engine.h>
+# endif
 # include <openssl/ossl_typ.h>
 # include "e_qat.h"
 

--- a/qat_fips.h
+++ b/qat_fips.h
@@ -86,7 +86,9 @@
 # include <openssl/rand.h>
 # include <openssl/sha.h>
 # include <openssl/err.h>
-# include <openssl/engine.h>
+# ifndef QAT_OPENSSL_3
+#  include <openssl/engine.h>
+# endif
 # include <openssl/evp.h>
 # include <openssl/async.h>
 # include <openssl/e_os2.h>

--- a/qat_hw_ccm.h
+++ b/qat_hw_ccm.h
@@ -46,7 +46,11 @@
 #ifndef QAT_HW_CCM_H
 # define QAT_HW_CCM_H
 
-# include <openssl/engine.h>
+# ifdef QAT_OPENSSL_3
+#  include <openssl/evp.h>
+# else
+#  include <openssl/engine.h>
+# endif
 
 # include "cpa.h"
 # include "cpa_types.h"

--- a/qat_hw_ciphers.h
+++ b/qat_hw_ciphers.h
@@ -48,7 +48,9 @@
 
 # ifdef QAT_HW
 
-# include <openssl/engine.h>
+# ifndef QAT_OPENSSL_3
+#  include <openssl/engine.h>
+# endif
 # include <openssl/ssl.h>
 # include <openssl/crypto.h>
 # include <openssl/aes.h>

--- a/qat_hw_ecx.c
+++ b/qat_hw_ecx.c
@@ -51,10 +51,11 @@
 #include <signal.h>
 #include <stdarg.h>
 
-#include "openssl/ossl_typ.h"
-#include "openssl/kdf.h"
-#include "openssl/evp.h"
-#include "openssl/ssl.h"
+#include <openssl/ossl_typ.h>
+#include <openssl/kdf.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/ssl.h>
 #include "e_qat.h"
 #include "qat_utils.h"
 #include "qat_hw_asym_common.h"

--- a/qat_hw_gcm.h
+++ b/qat_hw_gcm.h
@@ -46,7 +46,11 @@
 #ifndef QAT_HW_GCM_H
 #define QAT_HW_GCM_H
 
-# include <openssl/engine.h>
+# ifdef QAT_OPENSSL_3
+#  include <openssl/evp.h>
+# else
+#  include <openssl/engine.h>
+# endif
 
 # include "cpa.h"
 # include "cpa_types.h"

--- a/qat_hw_init.c
+++ b/qat_hw_init.c
@@ -128,6 +128,7 @@ int qat_use_signals(void)
        been initialised then there will be a further check within
        qat_engine_init inside a mutex to prevent a race condition. */
 
+#ifndef QAT_OPENSSL_PROVIDER
     if (unlikely(!engine_inited)) {
         ENGINE* e = ENGINE_by_id(engine_qat_id);
 
@@ -146,6 +147,7 @@ int qat_use_signals(void)
         ENGINE_free(e);
         ENGINE_QAT_PTR_RESET();
     }
+#endif
 
     return qat_use_signals_no_engine_start();
 }
@@ -226,6 +228,7 @@ int get_instance(int inst_type, int mem_type)
 
     unsigned int inst_count = 0;
     thread_local_variables_t * tlv = NULL;
+#ifndef QAT_OPENSSL_PROVIDER
     /* See qat_use_signals() above for more info on why it is safe to
        check engine_inited outside of a mutex in this case. */
     if (unlikely(!engine_inited)) {
@@ -245,6 +248,7 @@ int get_instance(int inst_type, int mem_type)
         ENGINE_free(e);
         ENGINE_QAT_PTR_RESET();
     }
+#endif
 
     tlv = qat_check_create_local_variables();
     if (unlikely(NULL == tlv)) {

--- a/qat_hw_sha3.h
+++ b/qat_hw_sha3.h
@@ -46,7 +46,11 @@
 #ifndef QAT_HW_SHA3_H
 # define QAT_HW_SHA3_H
 
-# include <openssl/engine.h>
+# ifdef QAT_OPENSSL_3
+#  include <openssl/evp.h>
+# else
+#  include <openssl/engine.h>
+# endif
 
 # include "cpa.h"
 # include "cpa_types.h"

--- a/qat_hw_sm3.h
+++ b/qat_hw_sm3.h
@@ -46,7 +46,11 @@
 #ifndef QAT_HW_SM3_H
 # define QAT_HW_SM3_H
 
+#ifdef QAT_OPENSSL_3
+# include <openssl/evp.h>
+#else
 # include <openssl/engine.h>
+#endif
 
 # include "cpa.h"
 # include "cpa_types.h"

--- a/qat_hw_sm4_cbc.h
+++ b/qat_hw_sm4_cbc.h
@@ -53,7 +53,9 @@
 #endif
 
 # ifdef ENABLE_QAT_HW_SM4_CBC
-# include <openssl/engine.h>
+# ifndef QAT_OPENSSL_3
+#  include <openssl/engine.h>
+# endif
 # include <openssl/ssl.h>
 # include <openssl/crypto.h>
 

--- a/qat_sw_ecx.c
+++ b/qat_sw_ecx.c
@@ -53,6 +53,7 @@
 #include <pthread.h>
 #include <openssl/rsa.h>
 #include <openssl/err.h>
+#include <openssl/rand.h>
 #include <string.h>
 #include <unistd.h>
 #include <signal.h>

--- a/qat_sw_ecx.h
+++ b/qat_sw_ecx.h
@@ -46,7 +46,9 @@
 #ifndef QAT_SW_ECX_H
 # define QAT_SW_ECX_H
 
-# include <openssl/engine.h>
+# ifndef QAT_OPENSSL_3
+#  include <openssl/engine.h>
+# endif
 # include <openssl/ossl_typ.h>
 
 

--- a/qat_sw_sm3.h
+++ b/qat_sw_sm3.h
@@ -46,7 +46,11 @@
 #ifndef QAT_SW_SM3_H
 # define QAT_SW_SM3_H
 
-# include <openssl/engine.h>
+# ifdef QAT_OPENSSL_3
+#  include <openssl/evp.h>
+# else
+#  include <openssl/engine.h>
+# endif
 # include <openssl/ossl_typ.h>
 
 /* QAT_SW SM3 methods declaration */

--- a/qat_sw_sm4_cbc.h
+++ b/qat_sw_sm4_cbc.h
@@ -46,8 +46,12 @@
 #ifndef QAT_SW_SM4_CBC_H
 # define QAT_SW_SM4_CBC_H
 
-# include <openssl/engine.h>
-# include <openssl/ossl_typ.h>
+# ifdef QAT_OPENSSL_3
+#  include <openssl/evp.h>
+# else
+#  include <openssl/engine.h>
+#  include <openssl/ossl_typ.h>
+#endif
 
 /* BabaSSL includes needed for sw method */
 # include <openssl/modes.h>

--- a/qat_sw_sm4_ccm.h
+++ b/qat_sw_sm4_ccm.h
@@ -46,7 +46,11 @@
 #ifndef QAT_SW_SM4_CCM_H
 # define QAT_SW_SM4_CCM_H
 
-# include <openssl/engine.h>
+# ifdef QAT_OPENSSL_3
+#  include <openssl/evp.h>
+# else
+#  include <openssl/engine.h>
+# endif
 # include <openssl/ossl_typ.h>
 # include <openssl/modes.h>
 

--- a/qat_sw_sm4_gcm.h
+++ b/qat_sw_sm4_gcm.h
@@ -46,7 +46,11 @@
 #ifndef QAT_SW_SM4_GCM_H
 # define QAT_SW_SM4_GCM_H
 
-# include <openssl/engine.h>
+# ifdef QAT_OPENSSL_3
+#  include <openssl/evp.h>
+# else
+#  include <openssl/engine.h>
+# endif
 # include <openssl/ossl_typ.h>
 # include <openssl/modes.h>
 


### PR DESCRIPTION
The ENGINE APIs are deprecated in OpenSSL v3, and Fedora 41 and RHEL 10 no longer ship the openssl/engine.h header by default.  This allows the build to succeed as a provider without engine.h present.

https://fedoraproject.org/wiki/Changes/OpensslDeprecateEngine

I have built and loaded this locally with OpenSSL 3.2.2 (F40 and EL9 as an engine, F41+ and EL10+ as a provider), 3.1.4 (F39), and 1.1.1k (EL8); hopefully your CI will check other environments.
