### PR TITLE
v1.9.0 release changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.68])
-AC_INIT([qatengine], [1.8.1], [])
+AC_INIT([qatengine], [1.9.0], [])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([.])
@@ -447,7 +447,7 @@ fi
 AM_CONDITIONAL([QAT_HW], [test "x$cflags_qat_hw" != "x"])
 case "$host_os" in
 linux*)
-    AS_IF([test `lspci -vnd 8086: | grep -c 4940` != "0"], [AC_SUBST([enable_qat20_oot], ["-DQAT20_OOT"])])
+    AS_IF([test `lspci -vnd 8086: | grep -c -E '4940|4942|4944|4946'` != "0"], [AC_SUBST([enable_qat20_oot], ["-DQAT20_OOT"])])
 esac
 AM_CONDITIONAL([QAT_4XXX], [test "x$enable_qat20_oot" != "x"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -379,9 +379,7 @@ then
     if grep "define OPENSSL_VERSION_NUMBER  0x1010"  $with_openssl_install_dir/include/openssl/opensslv.h
     then
       #OPENSSL 1.1.1
-      AC_MSG_NOTICE([Build QAT engine against OpenSSL 1.1.1])
-      libdir="\$(with_openssl_install_dir)/lib/engines-1.1"
-      AC_SUBST([OPENSSL_LIB], ["-Wl,-rpath,\$(with_openssl_install_dir)/lib -L\$(with_openssl_install_dir)/lib -lcrypto"])
+      AC_MSG_ERROR([OpenSSL 1.1.1 is not supported])
     else
       #OPENSSL 3.x.x
       if test "x$enable_qat_provider" = "xyes"
@@ -408,7 +406,7 @@ else
   includes_openssl="`pkg-config --variable=includedir libcrypto`"
   if grep "define OPENSSL_VERSION_NUMBER  0x1010" $includes_openssl/openssl/opensslv.h
   then
-      AC_MSG_NOTICE([Build QAT Engine against system OpenSSL 1.1.1])
+      AC_MSG_ERROR([OpenSSL 1.1.1 is not supported])
   else
     if test "x$enable_qat_provider" = "xyes"
     then
@@ -633,20 +631,6 @@ then
     fi
 fi
 
-if test "x$cflags_qat_hw" != "x"
-then
-    AC_CHECK_FILE(${with_openssl_install_dir}/include/openssl/ossl_typ.h,
-              [with_kdf_support_h=yes],
-              [with_kdf_support_h=no])
-    if test "x$with_kdf_support_h" = "xyes"
-    then
-        if grep "struct evp_kdf_ctx_st EVP_KDF_CTX" $with_openssl_install_dir/include/openssl/ossl_typ.h
-        then
-          AC_SUBST([cflags_qat_hw], ["${cflags_qat_hw} -DQAT_KDF_SUPPORT"])
-          AC_MSG_NOTICE([KDF structure support available])
-        fi
-    fi
-fi
 #System OpenSSL
 if test "x$with_openssl_install_dir" = "x"
 then

--- a/configure.ac
+++ b/configure.ac
@@ -618,9 +618,9 @@ fi
 if test "x$cflags_qat_sw_ipsec" != "x"
 then
   AS_IF([test "x$enable_qat_sw_gcm" != "xno"],
-        [cflags_qat_sw_ipsec+=" -DENABLE_QAT_SW_GCM"; AC_MSG_NOTICE([Accelerating GCM to Software (IPSec_mb)])])
+        [cflags_qat_sw_ipsec="${cflags_qat_sw_ipsec} -DENABLE_QAT_SW_GCM"; AC_MSG_NOTICE([Accelerating GCM to Software (IPSec_mb)])])
   AS_IF([test "x$enable_qat_sw_sha2" != "xno"],
-        [cflags_qat_sw_ipsec+=" -DENABLE_QAT_SW_SHA2"; AC_MSG_NOTICE([Accelerating SHA2 to Software (IPSec_mb)])])
+        [cflags_qat_sw_ipsec="${cflags_qat_sw_ipsec} -DENABLE_QAT_SW_SHA2"; AC_MSG_NOTICE([Accelerating SHA2 to Software (IPSec_mb)])])
 fi    
 
 if test "x$cflags_qat_hw" != "x" -a  "x$cflags_qat_sw" != "x"

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -35,7 +35,7 @@ in step 2 depending on the particular use case. Configure the required service o
 
 2. Set up the required crypto service(s)
 ```
-    for i in `lspci -D -d :4940| awk '{print $1}'`; do echo “sym;asym “ > /sys/bus/pci/devices/$i/qat/cfg_services;done
+    for i in `lspci -D -d :4940| awk '{print $1}'`; do echo “sym;asym“ > /sys/bus/pci/devices/$i/qat/cfg_services;done
 ```
 
 3. Bring up the QAT devices
@@ -55,13 +55,13 @@ in step 2 depending on the particular use case. Configure the required service o
 
 6. Add QAT group and Permission to the VF devices in the host
 ```
-    chown root.qat /dev/vfio/*
+    chown root:qat /dev/vfio/*
     chmod 660 /dev/vfio/*
 ```
 
 ### Image creation
 
-Docker images can be build using the below command with appropiate image name.
+Docker images can be built using the below command with appropriate image name.
 
 ```
 docker build --build-arg GID=$(getent group qat | cut -d ':' -f 3) -t <docker_image_name> <path-to-dockerfile> --no-cache

--- a/dockerfiles/haproxy/Dockerfile
+++ b/dockerfiles/haproxy/Dockerfile
@@ -3,7 +3,7 @@
 #                                                                         \
 #   BSD LICENSE                                                           \
 #                                                                         \
-#   Copyright(c) 2024-2025 Intel Corporation.                                  \
+#   Copyright(c) 2024-2025 Intel Corporation.                             \
 #   All rights reserved.                                                  \
 #                                                                         \
 #   Redistribution and use in source and binary forms, with or without    \
@@ -38,11 +38,11 @@
 ARG UBUNTU_BASE=ubuntu:22.04
 FROM ${UBUNTU_BASE} AS builder
 
-ARG OPENSSL_VERSION="openssl-3.0.15"
+ARG OPENSSL_VERSION="openssl-3.0.16"
 ARG QATLIB_VERSION="24.02.0"
-ARG QAT_ENGINE_VERSION="v1.8.1"
+ARG QAT_ENGINE_VERSION="v1.9.0"
 ARG IPSEC_MB_VERSION="v2.0"
-ARG IPP_CRYPTO_VERSION="v1.0.0"
+ARG IPP_CRYPTO_VERSION="v1.1.0"
 ARG HAPROXY_VERSION="v2.8.0"
 ARG GID
 ENV DEBIAN_FRONTEND=noninteractive
@@ -153,11 +153,14 @@ RUN apt-get purge -y linux-libc-dev
 
 FROM ${UBUNTU_BASE}
 
+RUN apt-get update && \
+    apt-get upgrade -y
+
 COPY --from=builder /usr/local/lib/libqat.so.4.2.0 /usr/lib/
 COPY --from=builder /usr/local/lib/libusdm.so.0.1.0 /usr/lib/
 COPY --from=builder /usr/local/lib/libIPSec_MB.so.2.0.0 /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/local/lib64/libcrypto.so.3 /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/local/lib/libcrypto_mb.so.12.0 /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/local/lib/intel64/libcrypto_mb.so.12.1 /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/local/bin/openssl /usr/bin/
 COPY --from=builder /usr/local/lib64/engines-3/qatengine.so /usr/lib/x86_64-linux-gnu/engines-3/qatengine.so
 COPY --from=builder /etc/group /etc/group

--- a/dockerfiles/qat_crypto_base/Dockerfile
+++ b/dockerfiles/qat_crypto_base/Dockerfile
@@ -3,7 +3,7 @@
 #                                                                         \
 #   BSD LICENSE                                                           \
 #                                                                         \
-#   Copyright(c) 2024-2025 Intel Corporation.                                  \
+#   Copyright(c) 2024-2025 Intel Corporation.                             \
 #   All rights reserved.                                                  \
 #                                                                         \
 #   Redistribution and use in source and binary forms, with or without    \
@@ -38,11 +38,11 @@
 ARG UBUNTU_BASE=ubuntu:22.04
 FROM ${UBUNTU_BASE} AS builder
 
-ARG OPENSSL_VERSION="openssl-3.0.15"
+ARG OPENSSL_VERSION="openssl-3.0.16"
 ARG QATLIB_VERSION="24.02.0"
-ARG QAT_ENGINE_VERSION="v1.8.1"
+ARG QAT_ENGINE_VERSION="v1.9.0"
 ARG IPSEC_MB_VERSION="v2.0"
-ARG IPP_CRYPTO_VERSION="v1.0.0"
+ARG IPP_CRYPTO_VERSION="v1.1.0"
 ARG GID
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -138,11 +138,14 @@ RUN apt-get purge -y linux-libc-dev
 
 FROM ${UBUNTU_BASE}
 
+RUN apt-get update && \
+    apt-get upgrade -y
+
 COPY --from=builder /usr/local/lib/libqat.so.4.2.0 /usr/lib/
 COPY --from=builder /usr/local/lib/libusdm.so.0.1.0 /usr/lib/
 COPY --from=builder /usr/local/lib/libIPSec_MB.so.2.0.0  /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/local/lib64/libcrypto.so.3 /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/local/lib/libcrypto_mb.so.12.0 /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/local/lib/intel64/libcrypto_mb.so.12.1 /usr/lib/x86_64-linux-gnu/
 COPY --from=builder /usr/local/bin/openssl /usr/bin/
 COPY --from=builder /usr/local/lib64/engines-3/qatengine.so /usr/lib/x86_64-linux-gnu/engines-3/
 COPY --from=builder /etc/group /etc/group

--- a/docs/bssl_support.md
+++ b/docs/bssl_support.md
@@ -14,7 +14,7 @@ This document details the capabilities, interfaces and limitations of the Boring
 ## Limitations
 Some limitations specific for the current BoringSSL\* Library:
 * NIST Binary Curves and NIST Koblitz Curves are not supported by BoringSSL\.
-* Supports QAT_HW and QAT_SW on Linux. QAT_SW and QAT_HW FreeBSD is not supported.
+* QAT_HW and QAT_SW Co-existence is not supported.
 * `RSA_padding_add_PKCS1_OAEP` function is exported by BoringSSL\* `libdecrepit.so`,
 so it needs to be linked in the BoringSSL\* Library. It may cause linking error while
 building with the system lack of that library.

--- a/docs/hardware_requirements.md
+++ b/docs/hardware_requirements.md
@@ -9,7 +9,7 @@ QAT_HW acceleration is supported on the platforms with the following QAT devices
 
 QAT_SW acceleration is supported in the platforms starting with [3rd Generation Intel&reg; Xeon&reg; Scalable Processors family][6] and later.
 
-[1]:https://www.intel.com/content/www/us/en/products/details/processors/xeon/scalable.html
+[1]:https://www.intel.com/content/www/us/en/products/details/processors/xeon.html
 [2]:https://www.intel.com/content/www/us/en/products/sku/125200/intel-quickassist-adapter-8970/downloads.html
 [3]:https://www.intel.com/content/www/us/en/products/sku/125199/intel-quickassist-adapter-8960/downloads.html
 [4]:https://www.intel.com/content/www/us/en/products/sku/80371/intel-communications-chipset-8950/specifications.html

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -107,3 +107,5 @@
   behaviour is observed in OpenSSL_SW as well [OpenSSL#21833](https://github.com/openssl/openssl/issues/21833)
 * Performance scaling is not linear in QAT2.0 supported platforms for ECDSA and Chacha-Poly algorithms.
 * Performance drop observed with ECDSAP256 algorithm in the OpenSSL speed tests with FreeBSD 14 intree driver.
+* Performance drop observed in QAT Engine with [async-nginx](https://github.com/intel/asynch_mode_nginx/tree/master) on FreeBSD OS with asymmetric and symmetric ciphers.
+* BoringSSL on FreeBSD OS is validated functionally with limited performance validation on Nginx QUIC POC.

--- a/docs/software_requirements.md
+++ b/docs/software_requirements.md
@@ -11,18 +11,18 @@ This release was validated on the following versions and expected to work on all
 and also from the latest versions from the links below.
 
 ## QAT_HW Drivers:
-* [Intel® QuickAssist Technology Driver for Linux\* HW Version 2.0][4] - **QAT20.L.1.1.50-00003**
-* [Intel® QuickAssist Technology Driver for Linux\* HW Version 1.x][5] - **QAT.L.4.26.0-00008**
+* [Intel® QuickAssist Technology Driver for Linux\* HW Version 2.0][4] - **QAT20.L.1.2.30-00078**
+* [Intel® QuickAssist Technology Driver for Linux\* HW Version 1.x][5] - **QAT.L.4.27.0-00006**
 * Intel® QuickAssist Technology Driver for FreeBSD\* HW Version 1.x and 2.0 - **QAT.B.3.14.31-00003** (FreeBSD 13.2)
 * [Intel® QATlib for Linux with intree driver][7] - **QATlib 24.09.0** & **QATlib 24.02.0** (for Dockerfile only)
 * [Intel®  QATlib for FreeBSD with intree driver(FreeBSD 14)][8] - **FreeBSD QATlib 23.09.0** (FreeBSD 14)
 
 ## QAT_SW Libraries:
-* [Intel&reg; Crypto Multi-buffer library][2] - **IPP Crypto v1.0.0** & **IPP Crypto 2021.10** (for BoringSSL only)
+* [Intel&reg; Crypto Multi-buffer library][2] - **IPP Crypto v1.1.0** & **IPP Crypto 2021.10** (for BoringSSL only)
 * [Intel&reg; Multi-Buffer crypto for IPsec Library release version][3] **v2.0**
 
 ## Crypto Libraries:
-* [OpenSSL\*][9] 3.0.15 & 3.2.3
+* [OpenSSL\*][9] 3.0.16, 3.2.4, 3.3.3 & 3.4.1
 * BoringSSL\* commit - [23ed9d3][10]
 * [Tongsuo][11] - 8.4.0 (BabaSSL)
 

--- a/driver_install.sh
+++ b/driver_install.sh
@@ -2,7 +2,7 @@
 
 #QAT_HW OOT driver Location
 QAT17_DRIVER=https://downloadmirror.intel.com/838409/QAT.L.4.27.0-00006.tar.gz
-QAT20_DRIVER=https://downloadmirror.intel.com/822703/QAT20.L.1.1.50-00003.tar.gz
+QAT20_DRIVER=https://downloadmirror.intel.com/843052/QAT20.L.1.2.30-00078.tar.gz
 
 #Supported Devices
 numC62xDevice=`lspci -vnd 8086: | grep -c "37c8\|37c9"`
@@ -10,7 +10,7 @@ numDh895xDevice=`lspci -vnd 8086: | grep -c "0435\|0443"`
 numC3xxxDevice=`lspci -vnd 8086: | grep -c "19e2\|19e3"`
 num200xxDevice=`lspci -vnd 8086: | grep -c "18ee\|18ef"`
 numC4xxxDevice=`lspci -vnd 8086: | grep -c "18a0\|18a1"`
-num4xxxDevice=`lspci -vnd 8086: | grep -c "4940"`
+num4xxxDevice=`lspci -vnd 8086: | grep -c "4940\|4942"`
 
 QAT_ENGINE_ROOT=$PWD
 

--- a/e_qat.c
+++ b/e_qat.c
@@ -1299,6 +1299,10 @@ int bind_qat(ENGINE *e, const char *id)
             DEBUG("QAT_HW GCM for Provider Enabled\n");
         }
 # endif
+# ifdef ENABLE_QAT_HW_CIPHERS
+        qat_hw_aes_cbc_hmac_sha_offload = 1;
+        INFO("QAT_HW CIPHERS for Provider Enabled\n");
+# endif
     }
 
     if (qat_sw_offload) {

--- a/e_qat.c
+++ b/e_qat.c
@@ -1147,7 +1147,12 @@ int bind_qat(ENGINE *e, const char *id)
 #endif
     if (!qat_hw_offload) {
 # ifndef QAT_SW
+#  ifdef QAT_BORINGSSL
+        fprintf(stderr, "QAT_HW device not available & QAT_SW not enabled. Exiting!\n");
+        return ret;
+#  else
         fprintf(stderr, "QAT_HW device not available & QAT_SW not enabled. Using OpenSSL_SW!\n");
+#  endif
 # endif
     }
 #endif

--- a/e_qat.c
+++ b/e_qat.c
@@ -169,13 +169,13 @@ int qat_fips_kat_test;
 const char *engine_qat_id = STR(QAT_ENGINE_ID);
 #if defined(QAT_HW) && defined(QAT_SW)
 const char *engine_qat_name =
-    "Reference implementation of QAT crypto engine(qat_hw & qat_sw) v1.8.1";
+    "Reference implementation of QAT crypto engine(qat_hw & qat_sw) v1.9.0";
 #elif QAT_HW
 const char *engine_qat_name =
-    "Reference implementation of QAT crypto engine(qat_hw) v1.8.1";
+    "Reference implementation of QAT crypto engine(qat_hw) v1.9.0";
 #else
 const char *engine_qat_name =
-    "Reference implementation of QAT crypto engine(qat_sw) v1.8.1";
+    "Reference implementation of QAT crypto engine(qat_sw) v1.9.0";
 #endif
 unsigned int engine_inited = 0;
 int fallback_to_openssl = 0;
@@ -1117,7 +1117,7 @@ int bind_qat(ENGINE *e, const char *id)
    int ret = 0;
 #ifdef QAT_HW
     char *config_section = NULL;
-# if !defined(QAT_HW_INTREE) && (defined(QAT20_OOT) || defined(__FreeBSD__))
+#ifdef ENABLE_QAT_HW_KPT
     Cpa32U dev_count = 0;
 # endif
 #endif
@@ -1132,7 +1132,7 @@ int bind_qat(ENGINE *e, const char *id)
 
     /* For QAT_HW, Check if the QAT_HW device is available */
 #ifdef QAT_HW
-# if !defined(QAT_HW_INTREE) && (defined(QAT20_OOT) || defined(__FreeBSD__))
+# ifdef ENABLE_QAT_HW_KPT
     if (icp_adf_get_numDevices(&dev_count) == CPA_STATUS_SUCCESS) {
         if (dev_count > 0) {
             qat_hw_offload = 1;
@@ -1144,7 +1144,7 @@ int bind_qat(ENGINE *e, const char *id)
         qat_hw_offload = 1;
         DEBUG("QAT HW device available\n");
     }
-#endif
+# endif
     if (!qat_hw_offload) {
 # ifndef QAT_SW
 #  ifdef QAT_BORINGSSL

--- a/qat_bssl.h
+++ b/qat_bssl.h
@@ -209,7 +209,7 @@ typedef pthread_once_t bssl_once_t;
 # define EC_KEY_can_sign(ec_key)                        (1)
 
 # define bssl_engine_get_rsa_method()           \
-    ENGINE_get_RSA_method(ENGINE_QAT_PTR_GET())
+    (ENGINE_QAT_PTR_GET() ? ENGINE_get_RSA_method(ENGINE_QAT_PTR_GET()) : NULL)
 # define bssl_engine_get_ecdsa_method()         \
     ENGINE_get_ECDSA_method(ENGINE_QAT_PTR_GET())
 

--- a/qat_hw_hkdf.c
+++ b/qat_hw_hkdf.c
@@ -204,16 +204,11 @@ int qat_hkdf_init(EVP_PKEY_CTX *ctx)
 
 #ifndef QAT_OPENSSL_3
     /* Software Ctrl functions are called here */
-# ifdef QAT_KDF_SUPPORT
-    EVP_PKEY_meth_get_init((EVP_PKEY_METHOD *)sw_hkdf_pmeth, &sw_init_fn_ptr);
-    EVP_KDF_CTX *kctx = EVP_KDF_CTX_new_id(EVP_KDF_HKDF);
-    qat_hkdf_ctx->sw_hkdf_ctx_data = kctx;
-# else
     QAT_HKDF_PKEY_CTX *kctx;
     EVP_PKEY_meth_get_init((EVP_PKEY_METHOD *)sw_hkdf_pmeth, &sw_init_fn_ptr);
     kctx = OPENSSL_zalloc(sizeof(*kctx));
     qat_hkdf_ctx->sw_hkdf_ctx_data = kctx;
-# endif
+
     EVP_PKEY_CTX_set_data(ctx, qat_hkdf_ctx->sw_hkdf_ctx_data);
     ret = (*sw_init_fn_ptr)(ctx);
     if (ret != 1) {
@@ -223,7 +218,6 @@ int qat_hkdf_init(EVP_PKEY_CTX *ctx)
     }
     EVP_PKEY_CTX_set_data(ctx, qat_hkdf_ctx);
 #endif
-
     qat_hkdf_ctx->hkdf_op_data =
         (CpaCyKeyGenHKDFOpData *) qat_mem_alloc(sizeof(CpaCyKeyGenHKDFOpData),
                 qat_hkdf_ctx->qat_svm, __FILE__, __LINE__);

--- a/qat_hw_hkdf.c
+++ b/qat_hw_hkdf.c
@@ -308,6 +308,14 @@ void qat_hkdf_cleanup(EVP_PKEY_CTX *ctx)
         QAT_MEM_FREE_NONZERO_BUFF(qat_hkdf_ctx->hkdf_op_data, qat_hkdf_ctx->qat_svm);
     }
     qat_hkdf_ctx->fallback = 0;
+#ifdef QAT_OPENSSL_PROVIDER
+    OPENSSL_free(qat_hkdf_ctx->prefix);
+    qat_hkdf_ctx->prefix = NULL;
+    OPENSSL_free(qat_hkdf_ctx->data);
+    qat_hkdf_ctx->data = NULL;
+    OPENSSL_free(qat_hkdf_ctx->label);
+    qat_hkdf_ctx->label = NULL;
+#endif
     OPENSSL_free(qat_hkdf_ctx);
     EVP_PKEY_CTX_set_data(ctx, NULL);
 

--- a/qat_hw_hkdf.h
+++ b/qat_hw_hkdf.h
@@ -84,7 +84,6 @@ typedef struct {
 #endif
 } QAT_HKDF_CTX;
 
-#ifndef QAT_KDF_SUPPORT
 typedef struct {
     int mode;
     const EVP_MD *md;
@@ -95,7 +94,6 @@ typedef struct {
     unsigned char info[QAT_HKDF_INFO_MAXBUF];
     size_t info_len;
 } QAT_HKDF_PKEY_CTX;
-#endif
 
 /* Function Declarations */
 int qat_hkdf_ctrl(EVP_PKEY_CTX *ctx, int type, int p1, void *p2);

--- a/qat_hw_sha3.h
+++ b/qat_hw_sha3.h
@@ -148,10 +148,15 @@ int qat_sha3_copy(QAT_KECCAK1600_CTX *to, const QAT_KECCAK1600_CTX *from);
 # endif
 typedef struct {
     uint64_t A[5][5];
+#if OPENSSL_VERSION_NUMBER >= 0x30300000
+    unsigned char buf[KECCAK1600_WIDTH / 8 - 32];
+#endif
     size_t block_size;          /* SW cached ctx->digest->block_size */
     size_t md_size;             /* SW output length, variable in XOF */
     size_t num;                 /* SW used bytes in below buffer */
+#if OPENSSL_VERSION_NUMBER < 0x30300000
     unsigned char buf[KECCAK1600_WIDTH / 8 - 32];
+#endif
     unsigned char pad;
 } KECCAK1600_CTX;
 

--- a/qat_hw_sm2.c
+++ b/qat_hw_sm2.c
@@ -1016,6 +1016,7 @@ int qat_sm2_sign(EVP_PKEY_CTX *ctx,
 #  endif
 # endif
     }
+    ECDSA_SIG_free(s);
     DEBUG("- FinishedP: %d\n", ret);
     return ret;
 }
@@ -1449,6 +1450,8 @@ int qat_sm2_verify(EVP_PKEY_CTX *ctx,
 #  endif
 # endif
     }
+    ECDSA_SIG_free(s);
+    OPENSSL_free(dgst);
     DEBUG("- Finished\n");
     return ret;
 }

--- a/qat_prov_ecx.h
+++ b/qat_prov_ecx.h
@@ -58,13 +58,17 @@
 typedef struct{
     int id; /* libcrypto internal */
     int name_id;
+# if OPENSSL_VERSION_NUMBER >= 0x30300000
+    /* NID for the legacy alg if there is one */
+    int legacy_alg;
+# endif
     char *type_name;
     const char *description;
     OSSL_PROVIDER *prov;
     CRYPTO_REF_COUNT references;
-#if OPENSSL_VERSION_NUMBER < 0x30200000
+# if OPENSSL_VERSION_NUMBER < 0x30200000
     CRYPTO_RWLOCK *lock;
-#endif
+# endif
     OSSL_FUNC_keymgmt_new_fn *new;
     OSSL_FUNC_keymgmt_free_fn *free;
     OSSL_FUNC_keymgmt_get_params_fn *get_params;
@@ -73,6 +77,10 @@ typedef struct{
     OSSL_FUNC_keymgmt_settable_params_fn *settable_params;
     OSSL_FUNC_keymgmt_gen_init_fn *gen_init;
     OSSL_FUNC_keymgmt_gen_set_template_fn *gen_set_template;
+# if OPENSSL_VERSION_NUMBER >= 0x30400000
+    OSSL_FUNC_keymgmt_gen_get_params_fn *gen_get_params;
+    OSSL_FUNC_keymgmt_gen_gettable_params_fn *gen_gettable_params;
+# endif
     OSSL_FUNC_keymgmt_gen_set_params_fn *gen_set_params;
     OSSL_FUNC_keymgmt_gen_settable_params_fn *gen_settable_params;
     OSSL_FUNC_keymgmt_gen_fn *gen;

--- a/qat_prov_init.c
+++ b/qat_prov_init.c
@@ -163,6 +163,8 @@ QAT_PROV_PARAMS qat_params;
 static void qat_teardown(void *provctx)
 {
     DEBUG("qatprovider teardown\n");
+    qat_free_ciphers();
+    qat_free_digest_meth();
     qat_engine_finish_int(NULL, QAT_RESET_GLOBALS);
     ERR_unload_QAT_strings();
 

--- a/qat_prov_kmgmt_dh.c
+++ b/qat_prov_kmgmt_dh.c
@@ -65,6 +65,10 @@ typedef struct
 {
     int id; /* libcrypto internal */
     int name_id;
+# if OPENSSL_VERSION_NUMBER >= 0x30300000
+    /* NID for the legacy alg if there is one */
+    int legacy_alg;
+# endif
     char *type_name;
     const char *description;
     OSSL_PROVIDER *prov;
@@ -84,6 +88,10 @@ typedef struct
     /* Generation, a complex constructor */
     OSSL_FUNC_keymgmt_gen_init_fn *gen_init;
     OSSL_FUNC_keymgmt_gen_set_template_fn *gen_set_template;
+# if OPENSSL_VERSION_NUMBER >= 0x30400000
+    OSSL_FUNC_keymgmt_gen_get_params_fn *gen_get_params;
+    OSSL_FUNC_keymgmt_gen_gettable_params_fn *gen_gettable_params;
+# endif
     OSSL_FUNC_keymgmt_gen_set_params_fn *gen_set_params;
     OSSL_FUNC_keymgmt_gen_settable_params_fn *gen_settable_params;
     OSSL_FUNC_keymgmt_gen_fn *gen;
@@ -349,7 +357,12 @@ static void *qat_dh_dup(const void *keydata_from, int selection)
         return NULL;
     return fun(keydata_from, selection);
 }
-
+# if OPENSSL_VERSION_NUMBER >= 0x30400000
+static const char *qat_dh_query_operation_name(int operation_id)
+{
+    return "DH";
+}
+# endif
 const OSSL_DISPATCH qat_dh_keymgmt_functions[] = {
     {OSSL_FUNC_KEYMGMT_NEW, (void (*)(void))qat_dh_newdata},
     {OSSL_FUNC_KEYMGMT_GEN_INIT, (void (*)(void))qat_dh_gen_init},
@@ -372,6 +385,10 @@ const OSSL_DISPATCH qat_dh_keymgmt_functions[] = {
     {OSSL_FUNC_KEYMGMT_IMPORT_TYPES, (void (*)(void))qat_dh_import_types},
     {OSSL_FUNC_KEYMGMT_EXPORT, (void (*)(void))qat_dh_export},
     {OSSL_FUNC_KEYMGMT_EXPORT_TYPES, (void (*)(void))qat_dh_export_types},
+# if OPENSSL_VERSION_NUMBER >= 0x30400000
+    { OSSL_FUNC_KEYMGMT_QUERY_OPERATION_NAME,
+      (void (*)(void))qat_dh_query_operation_name },
+# endif
     {OSSL_FUNC_KEYMGMT_DUP, (void (*)(void))qat_dh_dup},
     {0, NULL}};
 

--- a/qat_prov_kmgmt_dsa.c
+++ b/qat_prov_kmgmt_dsa.c
@@ -69,6 +69,10 @@ typedef struct
 {
     int id; /* libcrypto internal */
     int name_id;
+# if OPENSSL_VERSION_NUMBER >= 0x30300000
+    /* NID for the legacy alg if there is one */
+    int legacy_alg;
+# endif
     char *type_name;
     const char *description;
     OSSL_PROVIDER *prov;
@@ -88,6 +92,10 @@ typedef struct
     /* Generation, a complex constructor */
     OSSL_FUNC_keymgmt_gen_init_fn *gen_init;
     OSSL_FUNC_keymgmt_gen_set_template_fn *gen_set_template;
+# if OPENSSL_VERSION_NUMBER >= 0x30400000
+    OSSL_FUNC_keymgmt_gen_get_params_fn *gen_get_params;
+    OSSL_FUNC_keymgmt_gen_gettable_params_fn *gen_gettable_params;
+# endif
     OSSL_FUNC_keymgmt_gen_set_params_fn *gen_set_params;
     OSSL_FUNC_keymgmt_gen_settable_params_fn *gen_settable_params;
     OSSL_FUNC_keymgmt_gen_fn *gen;

--- a/qat_prov_kmgmt_ec.c
+++ b/qat_prov_kmgmt_ec.c
@@ -113,6 +113,10 @@ if (p != NULL) {                                                               \
 typedef struct{
     int id; /* libcrypto internal */
     int name_id;
+# if OPENSSL_VERSION_NUMBER >= 0x30300000
+    /* NID for the legacy alg if there is one */
+    int legacy_alg;
+# endif
     char *type_name;
     const char *description;
     OSSL_PROVIDER *prov;
@@ -132,6 +136,10 @@ typedef struct{
     /* Generation, a complex constructor */
     OSSL_FUNC_keymgmt_gen_init_fn *gen_init;
     OSSL_FUNC_keymgmt_gen_set_template_fn *gen_set_template;
+# if OPENSSL_VERSION_NUMBER >= 0x30400000
+    OSSL_FUNC_keymgmt_gen_get_params_fn *gen_get_params;
+    OSSL_FUNC_keymgmt_gen_gettable_params_fn *gen_gettable_params;
+# endif
     OSSL_FUNC_keymgmt_gen_set_params_fn *gen_set_params;
     OSSL_FUNC_keymgmt_gen_settable_params_fn *gen_settable_params;
     OSSL_FUNC_keymgmt_gen_fn *gen;

--- a/qat_prov_kmgmt_rsa.c
+++ b/qat_prov_kmgmt_rsa.c
@@ -58,6 +58,10 @@
 typedef struct{
     int id; /* libcrypto internal */
     int name_id;
+# if OPENSSL_VERSION_NUMBER >= 0x30300000
+    /* NID for the legacy alg if there is one */
+    int legacy_alg;
+# endif
     char *type_name;
     const char *description;
     OSSL_PROVIDER *prov;
@@ -77,6 +81,10 @@ typedef struct{
     /* Generation, a complex constructor */
     OSSL_FUNC_keymgmt_gen_init_fn *gen_init;
     OSSL_FUNC_keymgmt_gen_set_template_fn *gen_set_template;
+# if OPENSSL_VERSION_NUMBER >= 0x30400000
+    OSSL_FUNC_keymgmt_gen_get_params_fn *gen_get_params;
+    OSSL_FUNC_keymgmt_gen_gettable_params_fn *gen_gettable_params;
+# endif
     OSSL_FUNC_keymgmt_gen_set_params_fn *gen_set_params;
     OSSL_FUNC_keymgmt_gen_settable_params_fn *gen_settable_params;
     OSSL_FUNC_keymgmt_gen_fn *gen;

--- a/qat_prov_prf.c
+++ b/qat_prov_prf.c
@@ -208,6 +208,8 @@ static void qat_tls_prf_reset(void *vctx)
     OPENSSL_clear_free(ctx->sec, ctx->seclen);
     OPENSSL_cleanse(ctx->seed, ctx->seedlen);
     OPENSSL_cleanse(ctx->qat_userLabel, ctx->qat_userLabel_len);
+    OPENSSL_free(ctx->qat_userLabel);
+    ctx->qat_userLabel = NULL;
     memset(ctx, 0, sizeof(*ctx));
     ctx->provctx = provctx;
 }

--- a/qat_prov_sign_sm2.c
+++ b/qat_prov_sign_sm2.c
@@ -358,7 +358,9 @@ static int qat_sm2sig_digest_signverify_init(void *vpsm2ctx, const char *mdname,
         && qat_DER_w_algorithmIdentifier_SM2_with_MD(&pkt, -1, ctx->ec, md_nid)
         && QAT_WPACKET_finish(&pkt)) {
         QAT_WPACKET_get_total_written(&pkt, &ctx->aid_len);
+#if OPENSSL_VERSION_NUMBER < 0x30400000
         ctx->aid = QAT_WPACKET_get_curr(&pkt);
+#endif
     }
     QAT_WPACKET_cleanup(&pkt);
 
@@ -498,12 +500,12 @@ static int qat_sm2sig_get_ctx_params(void *vpsm2ctx, OSSL_PARAM *params)
 
     if (psm2ctx == NULL)
         return 0;
-
+#if OPENSSL_VERSION_NUMBER < 0x30400000
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_ALGORITHM_ID);
     if (p != NULL
         && !OSSL_PARAM_set_octet_string(p, psm2ctx->aid, psm2ctx->aid_len))
         return 0;
-
+#endif
     p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_DIGEST_SIZE);
     if (p != NULL && !OSSL_PARAM_set_size_t(p, psm2ctx->mdsize))
         return 0;

--- a/qat_prov_sign_sm2.h
+++ b/qat_prov_sign_sm2.h
@@ -73,7 +73,9 @@ typedef struct {
 
     /* The Algorithm Identifier of the combined signature algorithm */
     unsigned char aid_buf[OSSL_MAX_ALGORITHM_ID_SIZE];
+#if OPENSSL_VERSION_NUMBER < 0x30400000
     unsigned char *aid;
+#endif
     size_t  aid_len;
 
     /* main digest */
@@ -84,7 +86,6 @@ typedef struct {
     /* SM2 ID used for calculating the Z value */
     unsigned char *id;
     size_t id_len;
-
     const unsigned char *tbs;
     size_t tbs_len;
 } QAT_PROV_SM2_CTX;

--- a/qat_provider.h
+++ b/qat_provider.h
@@ -51,8 +51,8 @@
 # include <openssl/bio.h>
 # include <openssl/core_dispatch.h>
 
-# define QAT_PROVIDER_VERSION_STR "v1.8.1"
-# define QAT_PROVIDER_FULL_VERSION_STR "QAT Provider v1.8.1"
+# define QAT_PROVIDER_VERSION_STR "v1.9.0"
+# define QAT_PROVIDER_FULL_VERSION_STR "QAT Provider v1.9.0"
 
 # if defined(QAT_HW) && defined(QAT_SW)
 #  define QAT_PROVIDER_NAME_STR "QAT Provider for QAT_HW and QAT_SW"

--- a/qat_sw_init.c
+++ b/qat_sw_init.c
@@ -60,7 +60,9 @@
 #include <unistd.h>
 #include <ctype.h>
 #include <fcntl.h>
+# ifndef __FreeBSD__
 #include <sys/epoll.h>
+# endif
 #include <sys/types.h>
 #include <sys/eventfd.h>
 #include <unistd.h>
@@ -395,7 +397,7 @@ mb_thread_data* mb_check_thread_local(void)
                 goto err;
             }
             DEBUG("Polling thread created %lx, tlv %p\n",
-                  tlv->polling_thread, tlv);
+                  (uintptr_t)tlv->polling_thread, tlv);
         } else {
             /* External Polling assign it to the global pointer */
             mb_tlv = tlv;

--- a/qat_sw_polling.c
+++ b/qat_sw_polling.c
@@ -300,7 +300,7 @@ void multibuff_init_req_rates(mb_req_rates * req_rates)
 {
     req_rates->req_this_period = 0;
     multibuff_get_timeout_time(&mb_poll_timeout_time, mb_timeout_level);
-    clock_gettime(CLOCK_MONOTONIC_RAW, &req_rates->previous_time);
+    clock_gettime(clock_id, &req_rates->previous_time);
     req_rates->current_time = req_rates->previous_time;
 }
 
@@ -387,7 +387,7 @@ void multibuff_update_req_timeout(mb_req_rates * req_rates)
 {
     unsigned int existing_timeout_level;
 
-    clock_gettime(CLOCK_MONOTONIC_RAW, &req_rates->current_time);
+    clock_gettime(clock_id, &req_rates->current_time);
     if (multibuff_poll_check_for_timeout(mb_poll_timeout_time,
                                          req_rates->previous_time,
                                          req_rates->current_time) == 0) {
@@ -1408,7 +1408,7 @@ int qat_sw_poll()
     if (mb_tlv == NULL)
         return 1; /* Do nothing as there are no QAT_SW Requests */
 
-    clock_gettime(CLOCK_MONOTONIC_RAW, &current_time);
+    clock_gettime(clock_id, &current_time);
 
 #ifdef ENABLE_QAT_SW_ECX
     /* Deal with X25519 Keygen requests */
@@ -1418,7 +1418,7 @@ int qat_sw_poll()
             process_x25519_keygen_reqs(mb_tlv);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &x25519_keygen_previous_time);
+        clock_gettime(clock_id, &x25519_keygen_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1426,7 +1426,7 @@ int qat_sw_poll()
                                                  x25519_keygen_previous_time,
                                                  current_time) == 1) {
             process_x25519_keygen_reqs(mb_tlv);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &x25519_keygen_previous_time);
+            clock_gettime(clock_id, &x25519_keygen_previous_time);
         }
     }
 
@@ -1437,7 +1437,7 @@ int qat_sw_poll()
             process_x25519_derive_reqs(mb_tlv);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &x25519_derive_previous_time);
+        clock_gettime(clock_id, &x25519_derive_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1445,7 +1445,7 @@ int qat_sw_poll()
                                                  x25519_derive_previous_time,
                                                  current_time) == 1) {
             process_x25519_derive_reqs(mb_tlv);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &x25519_derive_previous_time);
+            clock_gettime(clock_id, &x25519_derive_previous_time);
         }
     }
 #endif
@@ -1458,7 +1458,7 @@ int qat_sw_poll()
             process_ecdsa_sign_reqs(mb_tlv, EC_P256);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap256_sign_previous_time);
+        clock_gettime(clock_id, &ecdsap256_sign_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1466,7 +1466,7 @@ int qat_sw_poll()
                                                  ecdsap256_sign_previous_time,
                                                  current_time) == 1) {
             process_ecdsa_sign_reqs(mb_tlv, EC_P256);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap256_sign_previous_time);
+            clock_gettime(clock_id, &ecdsap256_sign_previous_time);
         }
     }
 
@@ -1477,7 +1477,7 @@ int qat_sw_poll()
             process_ecdsa_sign_setup_reqs(mb_tlv, EC_P256);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap256_sign_setup_previous_time);
+        clock_gettime(clock_id, &ecdsap256_sign_setup_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1485,7 +1485,7 @@ int qat_sw_poll()
                                                  ecdsap256_sign_setup_previous_time,
                                                  current_time) == 1) {
             process_ecdsa_sign_setup_reqs(mb_tlv, EC_P256);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap256_sign_setup_previous_time);
+            clock_gettime(clock_id, &ecdsap256_sign_setup_previous_time);
         }
     }
 
@@ -1496,7 +1496,7 @@ int qat_sw_poll()
             process_ecdsa_sign_sig_reqs(mb_tlv, EC_P256);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap256_sign_sig_previous_time);
+        clock_gettime(clock_id, &ecdsap256_sign_sig_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1504,7 +1504,7 @@ int qat_sw_poll()
                                                  ecdsap256_sign_sig_previous_time,
                                                  current_time) == 1) {
             process_ecdsa_sign_sig_reqs(mb_tlv, EC_P256);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap256_sign_sig_previous_time);
+            clock_gettime(clock_id, &ecdsap256_sign_sig_previous_time);
         }
     }
 
@@ -1515,7 +1515,7 @@ int qat_sw_poll()
             process_ecdsa_sign_reqs(mb_tlv, EC_P384);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap384_sign_previous_time);
+        clock_gettime(clock_id, &ecdsap384_sign_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1523,7 +1523,7 @@ int qat_sw_poll()
                                                  ecdsap384_sign_previous_time,
                                                  current_time) == 1) {
             process_ecdsa_sign_reqs(mb_tlv, EC_P384);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap384_sign_previous_time);
+            clock_gettime(clock_id, &ecdsap384_sign_previous_time);
         }
     }
 
@@ -1534,7 +1534,7 @@ int qat_sw_poll()
             process_ecdsa_sign_setup_reqs(mb_tlv, EC_P384);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
          }
-         clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap384_sign_setup_previous_time);
+         clock_gettime(clock_id, &ecdsap384_sign_setup_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1542,7 +1542,7 @@ int qat_sw_poll()
                                                  ecdsap384_sign_setup_previous_time,
                                                  current_time) == 1) {
             process_ecdsa_sign_setup_reqs(mb_tlv, EC_P384);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap384_sign_setup_previous_time);
+            clock_gettime(clock_id, &ecdsap384_sign_setup_previous_time);
         }
     }
 
@@ -1553,7 +1553,7 @@ int qat_sw_poll()
              process_ecdsa_sign_sig_reqs(mb_tlv, EC_P384);
              snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap384_sign_sig_previous_time);
+        clock_gettime(clock_id, &ecdsap384_sign_sig_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1561,7 +1561,7 @@ int qat_sw_poll()
                                                  ecdsap384_sign_sig_previous_time,
                                                  current_time) == 1) {
             process_ecdsa_sign_sig_reqs(mb_tlv, EC_P384);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap384_sign_sig_previous_time);
+            clock_gettime(clock_id, &ecdsap384_sign_sig_previous_time);
         }
     }
 
@@ -1572,7 +1572,7 @@ int qat_sw_poll()
             process_ecdsa_verify_reqs(mb_tlv, EC_P256);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap256_verify_previous_time);
+        clock_gettime(clock_id, &ecdsap256_verify_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1580,7 +1580,7 @@ int qat_sw_poll()
                                                  ecdsap256_verify_previous_time,
                                                  current_time) == 1) {
             process_ecdsa_verify_reqs(mb_tlv, EC_P256);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap256_verify_previous_time);
+            clock_gettime(clock_id, &ecdsap256_verify_previous_time);
         }
     }
 
@@ -1591,7 +1591,7 @@ int qat_sw_poll()
             process_ecdsa_verify_reqs(mb_tlv, EC_P384);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap384_verify_previous_time);
+        clock_gettime(clock_id, &ecdsap384_verify_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1599,7 +1599,7 @@ int qat_sw_poll()
                                                  ecdsap384_verify_previous_time,
                                                  current_time) == 1) {
             process_ecdsa_verify_reqs(mb_tlv, EC_P384);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsap384_verify_previous_time);
+            clock_gettime(clock_id, &ecdsap384_verify_previous_time);
         }
     }
 #endif
@@ -1612,7 +1612,7 @@ int qat_sw_poll()
             process_ecdsa_sm2_sign_reqs(mb_tlv);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsa_sm2_sign_previous_time);
+        clock_gettime(clock_id, &ecdsa_sm2_sign_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1620,7 +1620,7 @@ int qat_sw_poll()
                                                  ecdsa_sm2_sign_previous_time,
                                                  current_time) == 1) {
             process_ecdsa_sm2_sign_reqs(mb_tlv);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsa_sm2_sign_previous_time);
+            clock_gettime(clock_id, &ecdsa_sm2_sign_previous_time);
         }
     }
 
@@ -1631,7 +1631,7 @@ int qat_sw_poll()
             process_ecdsa_sm2_verify_reqs(mb_tlv);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsa_sm2_verify_previous_time);
+        clock_gettime(clock_id, &ecdsa_sm2_verify_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1639,7 +1639,7 @@ int qat_sw_poll()
                                                  ecdsa_sm2_verify_previous_time,
                                                  current_time) == 1) {
             process_ecdsa_sm2_verify_reqs(mb_tlv);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &ecdsa_sm2_verify_previous_time);
+            clock_gettime(clock_id, &ecdsa_sm2_verify_previous_time);
         }
     }
 #endif
@@ -1652,7 +1652,7 @@ int qat_sw_poll()
             process_ecdh_keygen_reqs(mb_tlv, EC_P256);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &ecdhp256_keygen_previous_time);
+        clock_gettime(clock_id, &ecdhp256_keygen_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1660,7 +1660,7 @@ int qat_sw_poll()
                                                  ecdhp256_keygen_previous_time,
                                                  current_time) == 1) {
             process_ecdh_keygen_reqs(mb_tlv, EC_P256);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &ecdhp256_keygen_previous_time);
+            clock_gettime(clock_id, &ecdhp256_keygen_previous_time);
         }
     }
 
@@ -1671,7 +1671,7 @@ int qat_sw_poll()
             process_ecdh_compute_reqs(mb_tlv, EC_P256);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &ecdhp256_compute_previous_time);
+        clock_gettime(clock_id, &ecdhp256_compute_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1679,7 +1679,7 @@ int qat_sw_poll()
                                                  ecdhp256_compute_previous_time,
                                                  current_time) == 1) {
             process_ecdh_compute_reqs(mb_tlv, EC_P256);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &ecdhp256_compute_previous_time);
+            clock_gettime(clock_id, &ecdhp256_compute_previous_time);
         }
     }
 
@@ -1690,7 +1690,7 @@ int qat_sw_poll()
             process_ecdh_keygen_reqs(mb_tlv, EC_P384);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &ecdhp384_keygen_previous_time);
+        clock_gettime(clock_id, &ecdhp384_keygen_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1698,7 +1698,7 @@ int qat_sw_poll()
                                                  ecdhp384_keygen_previous_time,
                                                  current_time) == 1) {
             process_ecdh_keygen_reqs(mb_tlv, EC_P384);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &ecdhp384_keygen_previous_time);
+            clock_gettime(clock_id, &ecdhp384_keygen_previous_time);
         }
     }
 
@@ -1709,7 +1709,7 @@ int qat_sw_poll()
             process_ecdh_compute_reqs(mb_tlv, EC_P384);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &ecdhp384_compute_previous_time);
+        clock_gettime(clock_id, &ecdhp384_compute_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1717,7 +1717,7 @@ int qat_sw_poll()
                                                  ecdhp384_compute_previous_time,
                                                  current_time) == 1) {
             process_ecdh_compute_reqs(mb_tlv, EC_P384);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &ecdhp384_compute_previous_time);
+            clock_gettime(clock_id, &ecdhp384_compute_previous_time);
         }
     }
 
@@ -1728,7 +1728,7 @@ int qat_sw_poll()
             process_ecdh_keygen_reqs(mb_tlv, EC_SM2);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &sm2ecdh_keygen_previous_time);
+        clock_gettime(clock_id, &sm2ecdh_keygen_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1736,7 +1736,7 @@ int qat_sw_poll()
                                                  sm2ecdh_keygen_previous_time,
                                                  current_time) == 1) {
             process_ecdh_keygen_reqs(mb_tlv, EC_SM2);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &sm2ecdh_keygen_previous_time);
+            clock_gettime(clock_id, &sm2ecdh_keygen_previous_time);
         }
     }
 
@@ -1747,7 +1747,7 @@ int qat_sw_poll()
             process_ecdh_compute_reqs(mb_tlv, EC_SM2);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &sm2ecdh_compute_previous_time);
+        clock_gettime(clock_id, &sm2ecdh_compute_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1755,7 +1755,7 @@ int qat_sw_poll()
                                                  sm2ecdh_compute_previous_time,
                                                  current_time) == 1) {
             process_ecdh_compute_reqs(mb_tlv, EC_SM2);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &sm2ecdh_compute_previous_time);
+            clock_gettime(clock_id, &sm2ecdh_compute_previous_time);
         }
     }
 #endif
@@ -1768,7 +1768,7 @@ int qat_sw_poll()
             process_RSA_priv_reqs(mb_tlv, RSA_2K_LENGTH);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &rsa2k_priv_previous_time);
+        clock_gettime(clock_id, &rsa2k_priv_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
             snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1776,7 +1776,7 @@ int qat_sw_poll()
                                              rsa2k_priv_previous_time,
                                              current_time) == 1) {
             process_RSA_priv_reqs(mb_tlv, RSA_2K_LENGTH);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &rsa2k_priv_previous_time);
+            clock_gettime(clock_id, &rsa2k_priv_previous_time);
         }
     }
     /* Deal with rsa public key requests */
@@ -1786,7 +1786,7 @@ int qat_sw_poll()
             process_RSA_pub_reqs(mb_tlv, RSA_2K_LENGTH);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &rsa2k_pub_previous_time);
+        clock_gettime(clock_id, &rsa2k_pub_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
             snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1794,7 +1794,7 @@ int qat_sw_poll()
                                              rsa2k_pub_previous_time,
                                              current_time) == 1) {
             process_RSA_pub_reqs(mb_tlv, RSA_2K_LENGTH);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &rsa2k_pub_previous_time);
+            clock_gettime(clock_id, &rsa2k_pub_previous_time);
         }
     }
     /* Deal with rsa3k private key requests */
@@ -1804,7 +1804,7 @@ int qat_sw_poll()
             process_RSA_priv_reqs(mb_tlv, RSA_3K_LENGTH);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &rsa3k_priv_previous_time);
+        clock_gettime(clock_id, &rsa3k_priv_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
             snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1812,7 +1812,7 @@ int qat_sw_poll()
                                              rsa3k_priv_previous_time,
                                              current_time) == 1) {
             process_RSA_priv_reqs(mb_tlv, RSA_3K_LENGTH);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &rsa3k_priv_previous_time);
+            clock_gettime(clock_id, &rsa3k_priv_previous_time);
         }
     }
     /* Deal with rsa3k public key requests */
@@ -1822,7 +1822,7 @@ int qat_sw_poll()
             process_RSA_pub_reqs(mb_tlv, RSA_3K_LENGTH);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &rsa3k_pub_previous_time);
+        clock_gettime(clock_id, &rsa3k_pub_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
             snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1830,7 +1830,7 @@ int qat_sw_poll()
                                              rsa3k_pub_previous_time,
                                              current_time) == 1) {
             process_RSA_pub_reqs(mb_tlv, RSA_3K_LENGTH);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &rsa3k_pub_previous_time);
+            clock_gettime(clock_id, &rsa3k_pub_previous_time);
         }
     }
     /* Deal with rsa4k private key requests */
@@ -1840,7 +1840,7 @@ int qat_sw_poll()
             process_RSA_priv_reqs(mb_tlv, RSA_4K_LENGTH);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &rsa4k_priv_previous_time);
+        clock_gettime(clock_id, &rsa4k_priv_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
             snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1848,7 +1848,7 @@ int qat_sw_poll()
                                              rsa4k_priv_previous_time,
                                              current_time) == 1) {
             process_RSA_priv_reqs(mb_tlv, RSA_4K_LENGTH);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &rsa4k_priv_previous_time);
+            clock_gettime(clock_id, &rsa4k_priv_previous_time);
         }
     }
     /* Deal with rsa4k public key requests */
@@ -1858,7 +1858,7 @@ int qat_sw_poll()
             process_RSA_pub_reqs(mb_tlv, RSA_4K_LENGTH);
             snapshot_num_reqs -= MULTIBUFF_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &rsa4k_pub_previous_time);
+        clock_gettime(clock_id, &rsa4k_pub_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
             snapshot_num_reqs < MULTIBUFF_MAX_BATCH &&
@@ -1866,7 +1866,7 @@ int qat_sw_poll()
                                              rsa4k_pub_previous_time,
                                              current_time) == 1) {
             process_RSA_pub_reqs(mb_tlv, RSA_4K_LENGTH);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &rsa4k_pub_previous_time);
+            clock_gettime(clock_id, &rsa4k_pub_previous_time);
         }
     }
 #endif
@@ -1878,7 +1878,7 @@ int qat_sw_poll()
             process_sm3_init_reqs(mb_tlv);
             snapshot_num_reqs -= MULTIBUFF_SM3_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &sm3_init_previous_time);
+        clock_gettime(clock_id, &sm3_init_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_SM3_MAX_BATCH &&
@@ -1886,7 +1886,7 @@ int qat_sw_poll()
                                                  sm3_init_previous_time,
                                                  current_time) == 1) {
             process_sm3_init_reqs(mb_tlv);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &sm3_init_previous_time);
+            clock_gettime(clock_id, &sm3_init_previous_time);
         }
     }
 
@@ -1897,7 +1897,7 @@ int qat_sw_poll()
             process_sm3_update_reqs(mb_tlv);
             snapshot_num_reqs -= MULTIBUFF_SM3_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &sm3_update_previous_time);
+        clock_gettime(clock_id, &sm3_update_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_SM3_MAX_BATCH &&
@@ -1905,7 +1905,7 @@ int qat_sw_poll()
                                                  sm3_update_previous_time,
                                                  current_time) == 1) {
             process_sm3_update_reqs(mb_tlv);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &sm3_update_previous_time);
+            clock_gettime(clock_id, &sm3_update_previous_time);
         }
     }
     /* Deal with SM3 Final requests */
@@ -1915,7 +1915,7 @@ int qat_sw_poll()
             process_sm3_final_reqs(mb_tlv);
             snapshot_num_reqs -= MULTIBUFF_SM3_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &sm3_final_previous_time);
+        clock_gettime(clock_id, &sm3_final_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_SM3_MAX_BATCH &&
@@ -1923,7 +1923,7 @@ int qat_sw_poll()
                                                  sm3_final_previous_time,
                                                  current_time) == 1) {
             process_sm3_final_reqs(mb_tlv);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &sm3_final_previous_time);
+            clock_gettime(clock_id, &sm3_final_previous_time);
         }
     }
 #endif
@@ -1936,7 +1936,7 @@ int qat_sw_poll()
             process_mb_sm4_cbc_cipher_enc_reqs(mb_tlv);
             snapshot_num_reqs -= MULTIBUFF_SM4_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &sm4_cbc_cipher_previous_time);
+        clock_gettime(clock_id, &sm4_cbc_cipher_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_SM4_MAX_BATCH &&
@@ -1944,7 +1944,7 @@ int qat_sw_poll()
                                                  sm4_cbc_cipher_previous_time,
                                                  current_time) == 1) {
             process_mb_sm4_cbc_cipher_enc_reqs(mb_tlv);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &sm4_cbc_cipher_previous_time);
+            clock_gettime(clock_id, &sm4_cbc_cipher_previous_time);
         }
     }
 
@@ -1955,7 +1955,7 @@ int qat_sw_poll()
             process_mb_sm4_cbc_cipher_dec_reqs(mb_tlv);
             snapshot_num_reqs -= MULTIBUFF_SM4_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &sm4_cbc_cipher_dec_previous_time);
+        clock_gettime(clock_id, &sm4_cbc_cipher_dec_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_SM4_MAX_BATCH &&
@@ -1963,7 +1963,7 @@ int qat_sw_poll()
                                                  sm4_cbc_cipher_dec_previous_time,
                                                  current_time) == 1) {
             process_mb_sm4_cbc_cipher_dec_reqs(mb_tlv);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &sm4_cbc_cipher_dec_previous_time);
+            clock_gettime(clock_id, &sm4_cbc_cipher_dec_previous_time);
         }
     }
 #endif
@@ -1976,7 +1976,7 @@ int qat_sw_poll()
             process_mb_sm4_gcm_encrypt_reqs(mb_tlv);
             snapshot_num_reqs -= MULTIBUFF_SM4_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &sm4_gcm_encrypt_previous_time);
+        clock_gettime(clock_id, &sm4_gcm_encrypt_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_SM4_MAX_BATCH &&
@@ -1984,7 +1984,7 @@ int qat_sw_poll()
                                                  sm4_gcm_encrypt_previous_time,
                                                  current_time) == 1) {
             process_mb_sm4_gcm_encrypt_reqs(mb_tlv);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &sm4_gcm_encrypt_previous_time);
+            clock_gettime(clock_id, &sm4_gcm_encrypt_previous_time);
         }
     }
 
@@ -1995,7 +1995,7 @@ int qat_sw_poll()
             process_mb_sm4_gcm_decrypt_reqs(mb_tlv);
             snapshot_num_reqs -= MULTIBUFF_SM4_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &sm4_gcm_decrypt_previous_time);
+        clock_gettime(clock_id, &sm4_gcm_decrypt_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_SM4_MAX_BATCH &&
@@ -2003,7 +2003,7 @@ int qat_sw_poll()
                                                  sm4_gcm_decrypt_previous_time,
                                                  current_time) == 1) {
             process_mb_sm4_gcm_decrypt_reqs(mb_tlv);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &sm4_gcm_decrypt_previous_time);
+            clock_gettime(clock_id, &sm4_gcm_decrypt_previous_time);
         }
     }
 #endif
@@ -2016,7 +2016,7 @@ int qat_sw_poll()
             process_mb_sm4_ccm_encrypt_reqs(mb_tlv);
             snapshot_num_reqs -= MULTIBUFF_SM4_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &sm4_ccm_encrypt_previous_time);
+        clock_gettime(clock_id, &sm4_ccm_encrypt_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_SM4_MAX_BATCH &&
@@ -2024,7 +2024,7 @@ int qat_sw_poll()
                                                  sm4_ccm_encrypt_previous_time,
                                                  current_time) == 1) {
             process_mb_sm4_ccm_encrypt_reqs(mb_tlv);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &sm4_ccm_encrypt_previous_time);
+            clock_gettime(clock_id, &sm4_ccm_encrypt_previous_time);
         }
     }
 
@@ -2035,7 +2035,7 @@ int qat_sw_poll()
             process_mb_sm4_ccm_decrypt_reqs(mb_tlv);
             snapshot_num_reqs -= MULTIBUFF_SM4_MIN_BATCH;
         }
-        clock_gettime(CLOCK_MONOTONIC_RAW, &sm4_ccm_decrypt_previous_time);
+        clock_gettime(clock_id, &sm4_ccm_decrypt_previous_time);
     } else {
         if (snapshot_num_reqs > 0 &&
                 snapshot_num_reqs < MULTIBUFF_SM4_MAX_BATCH &&
@@ -2043,7 +2043,7 @@ int qat_sw_poll()
                                                  sm4_ccm_decrypt_previous_time,
                                                  current_time) == 1) {
             process_mb_sm4_ccm_decrypt_reqs(mb_tlv);
-            clock_gettime(CLOCK_MONOTONIC_RAW, &sm4_ccm_decrypt_previous_time);
+            clock_gettime(clock_id, &sm4_ccm_decrypt_previous_time);
         }
     }
 #endif

--- a/qat_sw_sm2.c
+++ b/qat_sw_sm2.c
@@ -76,8 +76,18 @@ typedef struct evp_signature_st {
     OSSL_FUNC_signature_newctx_fn *newctx;
     OSSL_FUNC_signature_sign_init_fn *sign_init;
     OSSL_FUNC_signature_sign_fn *sign;
+#if OPENSSL_VERSION_NUMBER >= 0x30400000
+    OSSL_FUNC_signature_sign_message_init_fn *sign_message_init;
+    OSSL_FUNC_signature_sign_message_update_fn *sign_message_update;
+    OSSL_FUNC_signature_sign_message_final_fn *sign_message_final;
+#endif
     OSSL_FUNC_signature_verify_init_fn *verify_init;
     OSSL_FUNC_signature_verify_fn *verify;
+#if OPENSSL_VERSION_NUMBER >= 0x30400000
+    OSSL_FUNC_signature_verify_message_init_fn *verify_message_init;
+    OSSL_FUNC_signature_verify_message_update_fn *verify_message_update;
+    OSSL_FUNC_signature_verify_message_final_fn *verify_message_final;
+#endif
     OSSL_FUNC_signature_verify_recover_init_fn *verify_recover_init;
     OSSL_FUNC_signature_verify_recover_fn *verify_recover;
     OSSL_FUNC_signature_digest_sign_init_fn *digest_sign_init;

--- a/qatengine-oot.spec
+++ b/qatengine-oot.spec
@@ -12,27 +12,27 @@
 %global fullversion  %{major}.%{minor}.%{rev}
 
 %global ippcp_major        12
-%global ippcp_minor        0
+%global ippcp_minor        1
 %global ippcp              cryptography-primitives
-%global ippcpver           1.0.0
+%global ippcpver           1.1.0
 %global ippcpfull          %{ippcp}-%{ippcpver}
 %global ippcpfullversion   %{ippcp_major}.%{ippcp_minor}
 
-%global openssl            openssl-3.0.15
-%global qatdriver          QAT20.L.1.1.50-00003
+%global openssl            openssl-3.0.16
+%global qatdriver          QAT20.L.1.2.30-00078
 
 %global openssl_source     %{_builddir}/%{openssl}
 %global openssl_install    %{buildroot}/%{_prefix}/local/ssl
 
 Name:       QAT_Engine
-Version:    1.8.0
+Version:    1.9.0
 Release:    1%{?dist}
 Summary:    Intel QuickAssist Technology(QAT) OpenSSL Engine
 License:    BSD-3-Clause AND OpenSSL
 
 Source0:    https://github.com/intel/QAT_Engine/archive/refs/tags/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:    https://github.com/openssl/openssl/releases/download/%{openssl}/%{openssl}.tar.gz#/%{openssl}.tar.gz
-Source2:    https://downloadmirror.intel.com/822703/%{qatdriver}.tar.gz#/%{qatdriver}.tar.gz
+Source2:    https://downloadmirror.intel.com/843052/%{qatdriver}.tar.gz#/%{qatdriver}.tar.gz
 %if !0%{?suse_version}
 Source3:    https://github.com/intel/ipp-crypto/archive/refs/tags/v%{ippcpver}.tar.gz#/%{ippcp}-%{ippcpver}.tar.gz
 Source4:    https://github.com/intel/intel-ipsec-mb/archive/refs/tags/v%{ipsecver}.tar.gz#/%{ipsecfull}.tar.gz
@@ -121,7 +121,7 @@ autoreconf -ivf
 
 %if !0%{?suse_version}
 # Enable QAT_HW & QAT_SW Co-existence acceleration
-./configure --with-openssl_install_dir=%{openssl_install} --with-qat_hw_dir=%{_builddir}/%{qatdriver} --enable-qat_sw
+./configure --with-openssl_install_dir=%{openssl_install} --with-qat_hw_dir=%{_builddir}/%{qatdriver} --enable-qat_sw --with-qat_sw_crypto_mb_install_dir=%{buildroot}/%{_prefix}/local --with-qat_sw_ipsec_mb_install_dir=%{buildroot}/%{_prefix}
 %else
 # Enable QAT_HW acceleration for SUSE
 ./configure --with-openssl_install_dir=%{openssl_install} --with-qat_hw_dir=%{_builddir}/%{qatdriver}

--- a/qatengine.spec
+++ b/qatengine.spec
@@ -13,7 +13,7 @@
 %endif
 
 Name:           qatengine
-Version:        1.8.1
+Version:        1.9.0
 Release:        1%{?dist}
 Summary:        Intel QuickAssist Technology (QAT) OpenSSL Engine
 
@@ -79,6 +79,9 @@ openssl engine -v %{name}
 %endif
 
 %changelog
+* Mon Mar 10 2025 Nagha Abirami <naghax.abirami@intel.com> - 1.9.0-1
+- Update to qatengine v1.9.0
+
 * Thu Jan 23 2025 Yogaraj Alamenda <yogaraj.alamenda@intel.com> - 1.8.1-1
 - Update to qatengine v1.8.1
 - Update e_qat_err files license info

--- a/test/tests.c
+++ b/test/tests.c
@@ -82,6 +82,7 @@ static int no_of_inst = 0;
 static int qat_keep_polling = 0;
 pthread_t *testapp_polling_threads;
 pthread_t *testapp_heartbeat_threads;
+int insecure_algorithms_enabled = 0;
 
 char *sw_algo_bitmap = NULL;
 char *hw_algo_bitmap = NULL;

--- a/test/tests.h
+++ b/test/tests.h
@@ -44,6 +44,8 @@
 #include <openssl/provider.h>
 #endif
 
+extern int insecure_algorithms_enabled;
+
 enum {
     R_RSA_512, R_RSA_1024, R_RSA_2048, R_RSA_3072, R_RSA_4096, R_RSA_8192,
     R_RSA_7680, R_RSA_15360, RSA_NUM

--- a/test/tests_rsa.c
+++ b/test/tests_rsa.c
@@ -3282,7 +3282,8 @@ err:
     if (ptext)
         OPENSSL_free(ptext);
 #endif
-    RSA_free(key);
+    if(size < 8192)
+        RSA_free(key);
     if (sig)
         OPENSSL_free(sig);
     if (verMsg)

--- a/test/tests_rsa.c
+++ b/test/tests_rsa.c
@@ -2703,7 +2703,6 @@ static int run_rsa(void *args)
     /* setup input hash message */
     for (i = 0; i < HASH_DATA_SIZE_NO_PADDING_8192; i++)
         HashData[i] = i % 16;
-
     /* setup new RSA key */
     key = RSA_new();
 
@@ -3282,8 +3281,8 @@ err:
 #else
     if (ptext)
         OPENSSL_free(ptext);
-    RSA_free(key);
 #endif
+    RSA_free(key);
     if (sig)
         OPENSSL_free(sig);
     if (verMsg)

--- a/test/tests_sm2.c
+++ b/test/tests_sm2.c
@@ -433,6 +433,7 @@ static int test_sm2(int count, int size, ENGINE *e, int print_output,
     }
     BIO_set_fp(out, stdout, BIO_NOCLOSE);
 
+    BIO_free(out);
     return test_sm2_sign_verify(count, size, e, print_output, verify, nid,
                                 curveName);
 }

--- a/test_bssl/test_bssl_rsa.c
+++ b/test_bssl/test_bssl_rsa.c
@@ -267,6 +267,12 @@ int qat_rsa_sign_test(RSA_METHOD *meth, RSA *rsa, const uint8_t *in_data,
         return 1; /* error */
     }
 
+    if (!meth->sign_raw) {
+        T_ERROR("QAT RSA sign_raw function is NULL.\n");
+        OPENSSL_free(out_data);
+        return 1; /* error */
+    }
+
     /* Signing */
     T_DUMP_RSA_SIGN_INPUT(in_data, in_len);
     meth->sign_raw(rsa, &out_len, out_data, in_len, in_data, in_len,


### PR DESCRIPTION
Contains below changes for v1.9.0 release

- Bug fixes, README update and version bump.
- Dockerfile version bump to 1.9.0 and vulnerability fix.
- Fixed boringssl segfault when no QAT HW devices are available
- QAT Engine and Provider compatibility issues fix with OpenSSL 3.3 and 3.4
- Fix KDF support finder with system openssl in configure.ac
- Add FreeBSD QAT_SW support
- Fixed memory leaks observed in qat hw provider
- Fixed aes-cbc-hmac-sha testapp insecure algo issue